### PR TITLE
Added types for substrate 3.0.0 compatibility

### DIFF
--- a/packages/apps-config/src/api/spec/index.ts
+++ b/packages/apps-config/src/api/spec/index.ts
@@ -26,6 +26,7 @@ import stablePoc from './stable-poc';
 import stafi from './stafi';
 import subsocial from './subsocial';
 import metablockchain from './metablockchain';
+import temp from './temp';
 
 // mapping from specName in state.getRuntimeVersion
 export default {
@@ -59,5 +60,8 @@ export default {
   stable_poc: stablePoc,
   stafi,
   subsocial,
-  'metablockchain-runtime': metablockchain
+  'metablockchain-runtime': {
+    ...metablockchain,
+    ...temp
+  }
 };

--- a/packages/apps-config/src/api/spec/temp.ts
+++ b/packages/apps-config/src/api/spec/temp.ts
@@ -1,0 +1,26 @@
+export default {
+    PerDispatchClassU32: {
+      normal: 'u32',
+      operational: 'u32',
+      mandatory: 'u32'
+    },
+    BlockLength: {
+      max: 'PerDispatchClassU32'
+    },
+    WeightPerClass: {
+      baseExtrinsic: 'Weight',
+      maxExtrinsic: 'Weight',
+      maxTotal: 'Option<Weight>',
+      reserved: 'Option<Weight>'
+    },
+    PerDispatchClassWeightsPerClass: {
+      normal: 'WeightPerClass',
+      operational: 'WeightPerClass',
+      mandatory: 'WeightPerClass'
+    },
+    BlockWeights: {
+      baseBlock: 'Weight',
+      maxBlock: 'Weight',
+      perClass: 'PerDispatchClassWeightsPerClass'
+    }
+};


### PR DESCRIPTION
This change will allow the explorer to connect with substrate 3.0.0 upgraded blockchain, without requiring to upgrade other libraries to the latest ones.